### PR TITLE
feat: Enable users to take advantage of the SARIF format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     default: 'false'
     required: false
 
+outputs:
+  sarif:
+    description: 'The SARIF file containing defects'
+
 runs:
   using: docker
   image: docker://quay.io/copr/vcs-diff-lint:latest

--- a/container/cmd
+++ b/container/cmd
@@ -29,6 +29,17 @@ set_linter_options()
     fi
 }
 
+get_pure_defects()
+{
+    set +e
+    if [[ -z "${linter_options[*]/--log-level=debug}" ]]; then
+        vcs-diff-lint >> defects.log
+    else
+        vcs-diff-lint "${linter_options[@]}" >> defects.log
+    fi
+    set -e
+}
+
 analyze_subdir()
 {
     echo
@@ -39,6 +50,7 @@ analyze_subdir()
         result=false
         return
     }
+    get_pure_defects
     vcs-diff-lint --print-fixed-errors "${linter_options[@]}" || result=false
 }
 
@@ -53,5 +65,13 @@ set_linter_options
 for subdir in $INPUT_SUBDIRECTORIES; do
     analyze_subdir "$subdir"
 done
+
+csgrep \
+    --strip-path-prefix "./" \
+    --mode=sarif \
+    --set-scan-prop="tool:vcs-diff-lint" \
+    --set-scan-prop="tool-url:https://github.com/fedora-copr/vcs-diff-lint#readme" \
+    "defects.log" > output.sarif
+echo "sarif=output.sarif" >> "${GITHUB_OUTPUT}"
 
 $result


### PR DESCRIPTION
Use `csgrep` to save defects in SARIF format and return the file's location in the `sarif` output.

Path to SARIF file can be accessed using `${{ steps.<id>.outputs.sarif }}`.

Tested in:

- https://github.com/jamacku/systemd-scopes/pull/1