### PR TITLE
Install csdiff from git master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY container/ /
 
 RUN dnf -y install dnf-plugins-core && \
     dnf -y copr enable @copr/vcs-diff-lint && \
+    dnf -y copr enable @codescan/csutils && \
     dnf install -y vcs-diff-lint git && \
     dnf clean all
 


### PR DESCRIPTION
For now, we need the csgrep --prepend-path-prefix option.