### PR TITLE
sarif: avoid reading the intermediate file

### DIFF
--- a/container/cmd
+++ b/container/cmd
@@ -48,7 +48,7 @@ populate_sarif_data()
         --mode=sarif \
         --set-scan-prop="tool:vcs-diff-lint" \
         --set-scan-prop="tool-url:https://github.com/fedora-copr/vcs-diff-lint#readme" \
-        "defects.log" >> "$rootdir/output.sarif" \
+        >> "$rootdir/output.sarif" \
     || true
 }
 


### PR DESCRIPTION
After e5fbf3001d2fa637895c20aefdf71a86efb5495c, it doesn't exist.