### PR TITLE
Revert "Upload SARIF only when defects are reported"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
           name: VCS Diff Lint SARIF
           path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
 
-      - if: ${{ failure() }}
+      - if: ${{ always() }}
         name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Reverts fedora-copr/vcs-diff-lint-action#12

If we don't upload SARIF `always()`, we won't get the defects fixed. See: https://github.com/fedora-copr/vcs-diff-lint-action/pull/12#issuecomment-1418747357