### PR TITLE
Avoid the ubiquitous GitHub github-code-scanning PR message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This action is built on top of [VCS Diff Lint](https://github.com/fedora-copr/vc
 name: Differential Linters
 
 on:
+  push:
   pull_request:
     branches: [ main ]
 
@@ -17,7 +18,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    if: github.event_name != 'push'
     permissions:
       # required for all workflows
       security-events: write
@@ -34,18 +35,18 @@ jobs:
         name: VCS Diff Lint
         uses: fedora-copr/vcs-diff-lint-action@v1
 
-      - if: ${{ always() }}
-        name: Upload artifact with detected defects in SARIF format
+      - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v3
         with:
           name: VCS Diff Lint SARIF
           path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}
 
-      - if: ${{ always() }}
-        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
+      - name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -12,21 +12,10 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-
     steps:
       - name: Repository checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
We have to specify the 'push' target.  This avoids the message:

    You have successfully added a new vcs-diff-lint configuration
    .github/workflows/python-diff-lint.yml:python-lint-job. As part of the
    setup process, we have scanned this repository and found no existing
    alerts. In the future, you will see all code scanning alerts on the
    repository Security tab.

... in every single PR.  Without 'push' defined GitHub thinks that the linter action is added in every single pull-request.

While on it, move the 'if' statements down so the rules are slightly more readable.

Related: redhat-plumbers-in-action/differential-shellcheck#215
