### PR TITLE
container: empty list of SARIF events for "push" events

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This action is built on top of [VCS Diff Lint](https://github.com/fedora-copr/vc
 name: Differential Linters
 
 on:
+  # For push, we "do nothing".  But it needs to be specified, see #17
+  push:
   pull_request:
     branches: [ main ]
 
@@ -34,18 +36,18 @@ jobs:
         name: VCS Diff Lint
         uses: fedora-copr/vcs-diff-lint-action@v1
 
-      - if: ${{ always() }}
-        name: Upload artifact with detected defects in SARIF format
+      - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v3
         with:
           name: VCS Diff Lint SARIF
           path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}
 
-      - if: ${{ always() }}
-        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
+      - name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}
 ```
 
 ## Options

--- a/container/cmd
+++ b/container/cmd
@@ -63,17 +63,21 @@ analyze_subdir()
     vcs-diff-lint --print-fixed-errors "${linter_options[@]}" || result=false
 }
 
-git config --global --add safe.directory '*'
-git config --global advice.detachedHead false
-git fetch origin "$target_branch:$target_branch" &>/dev/null
+if test "$GITHUB_EVENT_NAME" = 'pull_request'; then
+    git config --global --add safe.directory '*'
+    git config --global advice.detachedHead false
+    git fetch origin "$target_branch:$target_branch" &>/dev/null
 
-test -z "$INPUT_SUBDIRECTORY" || INPUT_SUBDIRECTORIES=$INPUT_SUBDIRECTORY
-test -z "$INPUT_SUBDIRECTORIES" && INPUT_SUBDIRECTORIES=.
+    test -z "$INPUT_SUBDIRECTORY" || INPUT_SUBDIRECTORIES=$INPUT_SUBDIRECTORY
+    test -z "$INPUT_SUBDIRECTORIES" && INPUT_SUBDIRECTORIES=.
 
-set_linter_options
-for subdir in $INPUT_SUBDIRECTORIES; do
-    analyze_subdir "$subdir"
-done
+    set_linter_options
+    for subdir in $INPUT_SUBDIRECTORIES; do
+        analyze_subdir "$subdir"
+    done
+else
+    touch "$rootdir/output.sarif.err"
+fi
 
 csgrep \
     --mode=sarif \


### PR DESCRIPTION
    Fix ubiquitous 'github-code-scanning' PR message
    
    We have to specify the 'push' target to avoid the message
    
    | You have successfully added a new vcs-diff-lint configuration
    | .github/workflows/python-diff-lint.yml:python-lint-job. As part of the
    | setup process, we have scanned this repository and found no existing
    | alerts. In the future, you will see all code scanning alerts on the
    | repository Security tab.
    
    ... appearing in every single PR.  Without the 'push' trigger defined,
    GitHub thinks that the linter action is being added in every single
    pull-request.
    
    Though, since the workflow is newly run for 'push' events, we have to do
    some reasonable "no-op".  For the first implementation, we simply try to
    generate an empty list of issues (therefore the container fix here).
    
    For the vcs-diff-lint case, it doesn't make too much sense to do the
    analysis on pushes.  At least not in the "basic" differential use-case
    we have now.  We could e.g. do full-scan in the future if there was
    demand for it.
    
    So I'm fixing the example in README.md to define "push", too.  While on
    it, move the 'if' statements down so the rules are slightly more
    readable.
    
    Related: redhat-plumbers-in-action/differential-shellcheck#215
    Closes: #17
    Closes: #16

