### PR TITLE
ci: run `publish-release` on `push: tags` trigger

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,8 @@
 name: GitHub Tag Update
 
 on:
+  push:
+    tags: [ v*.*.* ]
   release:
     types: [ published, edited ]
 


### PR DESCRIPTION
Upstream Issue:
- https://github.com/Actions-R-Us/actions-tagger/issues/78