### PR TITLE
avoid useless warnings in CI

### DIFF
--- a/container/cmd
+++ b/container/cmd
@@ -71,6 +71,8 @@ fi
 if test "$GITHUB_EVENT_NAME" = 'pull_request'; then
     git config --global --add safe.directory '*'
     git config --global advice.detachedHead false
+    git config --global init.defaultBranch main
+
     git fetch origin "$target_branch:$target_branch" &>/dev/null
 
     test -z "$INPUT_SUBDIRECTORY" || INPUT_SUBDIRECTORIES=$INPUT_SUBDIRECTORY


### PR DESCRIPTION
hint: Using 'master' as the name for the initial branch. This default branch name hint: is subject to change. To configure the initial branch name to use in all hint: of your new repositories, which will suppress this warning, call: hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and hint: 'development'. The just-created branch can be renamed via this command: hint:
hint: 	git branch -m <name>